### PR TITLE
feat: Processes' stats with realtime-chart update

### DIFF
--- a/process-visualizer/Cargo.lock
+++ b/process-visualizer/Cargo.lock
@@ -159,6 +159,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +233,7 @@ name = "process_visualizer"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "lazy_static",
  "regex",
  "serde",
  "serde_json",

--- a/process-visualizer/Cargo.toml
+++ b/process-visualizer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4.24"
+lazy_static = "1.4.0"
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/process-visualizer/src/main.rs
+++ b/process-visualizer/src/main.rs
@@ -1,9 +1,13 @@
 mod process_collector;
 
 use std::{
+  fs::File,
+  io::{Read, Write},
+  net::TcpListener,
   path::Path,
   process::Command,
-  thread,
+  // NOTE: `Multi-producers, single-consumer FIFO queue communication primitives`.
+  // sync::{mpsc::channel, Arc, Mutex},
   time::{Duration, Instant},
 };
 
@@ -27,9 +31,13 @@ fn main() -> std::io::Result<()> {
 
   let mut start_time = Instant::now();
   loop {
+    // let (tx, rx) = channel::<ProcAttribute>();
+
     let elapsed_time = start_time.elapsed().as_secs();
     if elapsed_time < UPDATE_INTERVAL_SEC {
-      thread::sleep(Duration::from_secs(UPDATE_INTERVAL_SEC - elapsed_time));
+      std::thread::sleep(Duration::from_secs(
+        UPDATE_INTERVAL_SEC - elapsed_time,
+      ));
     }
     start_time = Instant::now();
 
@@ -45,8 +53,75 @@ fn main() -> std::io::Result<()> {
       convert_process_stat_to_string(proc_invoker.stdout.as_mut().unwrap())?;
     redirect_procs_stat_to_file(output, Path::new(""));
 
-    serve_process_stats_from("127.0.0.1", 9999, FILE_NAME.to_owned())
-      .unwrap_or_default();
-    thread::sleep(Duration::from_secs(5));
+    // NOTE: Open the stats file simultaneously.
+    let stat_file = File::open(FILE_NAME).expect("Failed to open stats file");
+
+    // NOTE: Mapping the raw string data into a `ProcAttribute` structure.
+    let proc_attr = ProcAttribute::new(0, 0., 0., 0, "");
+    let procs_stat_vec = Vec::<ProcAttribute>::new();
+    proc_attr.mapping_attr_from(stat_file, &procs_stat_vec);
+
+    // let procs: Box<dyn std::any::Any> = Box::new(procs_stat_vec.clone());
+
+    // let procs = match procs.downcast::<Vec<ProcAttribute>>() {
+    //   Ok(procs) => procs,
+    //   Err(why) => panic!("{:?}", why.as_ref()),
+    // };
+    // let procs_stat_vec = procs.into_boxed_slice().into_vec();
+    // println!(
+    //   "INFO: {:?} processes counter, at {:?}",
+    //   procs_stat_vec.clone().into_boxed_slice().into_vec().len(),
+    //   process_collector::date_time_helper().unwrap(),
+    // );
+
+    let (host, port) = ("127.0.0.1", 9999);
+    let addr = format!("{}:{}", host, port);
+    let listener = TcpListener::bind(addr).unwrap();
+    println!(
+      "INFO: Server hosted at address {:?}, {:?}",
+      listener.local_addr().unwrap(),
+      date_time_helper().unwrap()
+    );
+
+    for stream in listener.incoming() {
+      let mut buffer = [0; 1024];
+      let mut response = String::from("HTTP/1.1 200 OK \r\n");
+      response.push_str("Access-Control-Allow-Origin: *\r\n");
+      response.push_str("Connection: Keep-Alive\r\n");
+      response.push_str("Content-Type: application/json\r\n");
+      response.push_str("\r\n");
+
+      match stream {
+        Ok(mut stream) => loop {
+          stream.read(&mut buffer)?;
+          let json_response = match serde_json::to_string(&procs_stat_vec) {
+            Ok(response) => response + "\r\n",
+            Err(_) => "[]".to_string(),
+          };
+          response.push_str(&json_response);
+          stream.write_all(response.as_bytes())?;
+          stream.flush().unwrap();
+        },
+        Err(e) => {
+          println!("Error: {}", e);
+        }
+      }
+    }
+
+    // let wrapper = Arc::new(Mutex::new(tx));
+    // let procs_data_aggregate = std::thread::spawn(move || {
+    //   for proc_data in procs_stat_vec {
+    //     let (tx, proc_data) =
+    //       (wrapper.lock().unwrap(), Arc::new(Mutex::new(proc_data)));
+    //     let mut lock_data = proc_data.lock().unwrap();
+    //     *lock_data += ProcAttribute::new(0, 0., 0., 0, "");
+    //     tx.send(lock_data.to_owned()).unwrap();
+    //   }
+    // });
+
+    // serve_process_stats_from("127.0.0.1", 9999, procs_stat_vec)
+    //   .unwrap_or_default();
+    // procs_data_aggregate.join().unwrap();
+    std::thread::sleep(Duration::from_secs(5));
   }
 }

--- a/process-visualizer/src/main.rs
+++ b/process-visualizer/src/main.rs
@@ -17,6 +17,17 @@ use crate::process_collector::*;
 const UPDATE_INTERVAL_SEC: u64 = 5;
 
 fn main() -> std::io::Result<()> {
+  println!(
+    "{:?}",
+    ProcAttribute::manual_alloc_process(ProcAttribute {
+      pid: 10,
+      cpu: 10.01,
+      memory: 12.21,
+      priority: 10,
+      execution: String::from("")
+    })
+  );
+
   // NOTE: Open process-statistics file for writing with an initial update.
   let mut proc_invoker = invoke_process_with(
     Command::new("ps"),
@@ -31,8 +42,6 @@ fn main() -> std::io::Result<()> {
 
   let mut start_time = Instant::now();
   loop {
-    // let (tx, rx) = channel::<ProcAttribute>();
-
     let elapsed_time = start_time.elapsed().as_secs();
     if elapsed_time < UPDATE_INTERVAL_SEC {
       std::thread::sleep(Duration::from_secs(
@@ -40,39 +49,6 @@ fn main() -> std::io::Result<()> {
       ));
     }
     start_time = Instant::now();
-
-    let mut proc_invoker = invoke_process_with(
-      Command::new("ps"),
-      vec!["-eo", "pid,%cpu,%mem,pri,comm"], // NOTE: `pcpu == %cpu` -> `p` stands for percentage.
-    )
-    .unwrap();
-    proc_invoker.wait()?;
-
-    // NOTE: Over-complicated as described on the `process_collector.rs`.
-    let output =
-      convert_process_stat_to_string(proc_invoker.stdout.as_mut().unwrap())?;
-    redirect_procs_stat_to_file(output, Path::new(""));
-
-    // NOTE: Open the stats file simultaneously.
-    let stat_file = File::open(FILE_NAME).expect("Failed to open stats file");
-
-    // NOTE: Mapping the raw string data into a `ProcAttribute` structure.
-    let proc_attr = ProcAttribute::new(0, 0., 0., 0, "");
-    let procs_stat_vec = Vec::<ProcAttribute>::new();
-    proc_attr.mapping_attr_from(stat_file, &procs_stat_vec);
-
-    // let procs: Box<dyn std::any::Any> = Box::new(procs_stat_vec.clone());
-
-    // let procs = match procs.downcast::<Vec<ProcAttribute>>() {
-    //   Ok(procs) => procs,
-    //   Err(why) => panic!("{:?}", why.as_ref()),
-    // };
-    // let procs_stat_vec = procs.into_boxed_slice().into_vec();
-    // println!(
-    //   "INFO: {:?} processes counter, at {:?}",
-    //   procs_stat_vec.clone().into_boxed_slice().into_vec().len(),
-    //   process_collector::date_time_helper().unwrap(),
-    // );
 
     let (host, port) = ("127.0.0.1", 9999);
     let addr = format!("{}:{}", host, port);
@@ -83,6 +59,62 @@ fn main() -> std::io::Result<()> {
       date_time_helper().unwrap()
     );
 
+    std::thread::spawn(move || {
+      loop {
+        let mut proc_invoker = invoke_process_with(
+          Command::new("ps"),
+          vec!["-eo", "pid,%cpu,%mem,pri,comm"], // NOTE: `pcpu == %cpu` -> `p` stands for percentage.
+        )
+        .unwrap();
+        proc_invoker.wait().unwrap();
+
+        // NOTE: Over-complicated as described on the `process_collector.rs`.
+        let output =
+          convert_process_stat_to_string(proc_invoker.stdout.as_mut().unwrap())
+            .unwrap_or_default();
+        redirect_procs_stat_to_file(output, Path::new(""));
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        // NOTE: Open the stats file simultaneously.
+        let stat_file =
+          File::open(FILE_NAME).expect("Failed to open stats file");
+
+        // NOTE: Mapping the raw string data into a `ProcAttribute` structure.
+        let mut procs_stat_vec = Vec::<ProcAttribute>::new();
+        let file_lines =
+          read_file_ignore_first_line(stat_file.try_clone().unwrap());
+        for stat_line_data in file_lines {
+          let stat_line_data = stat_line_data.trim_start();
+          let proc_data =
+            ProcAttribute::mapping_attr_from(stat_line_data.to_string());
+          procs_stat_vec.push(proc_data);
+        }
+
+        // NOTE: Experimental `Box` heap allocator feature for our implementation.
+        let procs: Box<dyn std::any::Any> = Box::new(procs_stat_vec.clone());
+
+        let procs = match procs.downcast::<Vec<ProcAttribute>>() {
+          Ok(procs) => procs,
+          Err(why) => panic!("{:?}", why.as_ref()),
+        };
+        let procs_stat_vec = procs.into_boxed_slice().into_vec();
+        println!(
+          "INFO: {:?} processes counter, at {:?}",
+          procs_stat_vec.clone().into_boxed_slice().into_vec().len(),
+          process_collector::date_time_helper().unwrap(),
+        );
+
+        // NOTE: Accessing the entire collector's stats data to prevent data corruption/intersection/intervention.
+        ProcAttribute::assign_to_global_var(procs_stat_vec);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+      }
+    });
+
+    // NOTE: Using `lazy_static` crate to avoid redundant initialization variables with static lifetime.
+    let guard = DATA_MUTEX.lock().unwrap();
+    let procs_stat_vec_clone = *guard;
+    println!("=====> Clone {:?}", procs_stat_vec_clone);
+
     for stream in listener.incoming() {
       let mut buffer = [0; 1024];
       let mut response = String::from("HTTP/1.1 200 OK \r\n");
@@ -92,36 +124,24 @@ fn main() -> std::io::Result<()> {
       response.push_str("\r\n");
 
       match stream {
-        Ok(mut stream) => loop {
+        Ok(mut stream) => {
           stream.read(&mut buffer)?;
-          let json_response = match serde_json::to_string(&procs_stat_vec) {
+
+          let json_response = match serde_json::to_string(&procs_stat_vec_clone)
+          {
             Ok(response) => response + "\r\n",
             Err(_) => "[]".to_string(),
           };
+          println!("=====> Response {}", json_response);
           response.push_str(&json_response);
           stream.write_all(response.as_bytes())?;
           stream.flush().unwrap();
-        },
+        }
         Err(e) => {
           println!("Error: {}", e);
         }
       }
     }
-
-    // let wrapper = Arc::new(Mutex::new(tx));
-    // let procs_data_aggregate = std::thread::spawn(move || {
-    //   for proc_data in procs_stat_vec {
-    //     let (tx, proc_data) =
-    //       (wrapper.lock().unwrap(), Arc::new(Mutex::new(proc_data)));
-    //     let mut lock_data = proc_data.lock().unwrap();
-    //     *lock_data += ProcAttribute::new(0, 0., 0., 0, "");
-    //     tx.send(lock_data.to_owned()).unwrap();
-    //   }
-    // });
-
-    // serve_process_stats_from("127.0.0.1", 9999, procs_stat_vec)
-    //   .unwrap_or_default();
-    // procs_data_aggregate.join().unwrap();
     std::thread::sleep(Duration::from_secs(5));
   }
 }

--- a/process-visualizer/src/process_collector.rs
+++ b/process-visualizer/src/process_collector.rs
@@ -119,9 +119,7 @@ impl ProcAttribute {
     let memory = words_per_line[2].parse::<f32>().unwrap_or_default();
     let priority = words_per_line[3].parse::<u8>().unwrap_or_default();
     let execution = words_per_line[4];
-    let proc_obj =
-      ProcAttribute::new(pid, cpu, memory, priority, execution.to_string());
-    proc_obj
+    ProcAttribute::new(pid, cpu, memory, priority, execution.to_string())
   }
 
   pub fn manual_alloc_process(self) -> Self {
@@ -140,7 +138,6 @@ impl ProcAttribute {
     unsafe {
       let mut guard = DATA_MUTEX.lock().unwrap();
       DATA_PROCESSES = Box::leak(procs_stat_vec.into_boxed_slice()).into();
-      println!("=====> Assign {:#?}", DATA_PROCESSES);
       *guard = &DATA_PROCESSES;
     }
   }
@@ -211,9 +208,9 @@ where
 {
   let proc_stat_data = stat.to_string();
   let default_path = Box::new(Path::new(FILE_NAME));
-  if let Some("") = path.to_str()
-  /* Syntax equivalent with: `if path.to_str() == Some("")` */
-  {
+
+  // NOTE: Syntax equivalent with: `if path.to_str() == Some("")`.
+  if let Some("") = path.to_str() {
     unsafe {
       path = *Box::into_raw(default_path);
     }
@@ -274,6 +271,7 @@ mod test {
   fn test_init_proc_attr() {
     let proc_attr = ProcAttribute::new(0, 0., 0., 0, "".to_string());
     assert_eq!(proc_attr.execution, "");
+    assert_eq!(proc_attr.execution, ProcAttribute::default().execution);
     assert_ne!(proc_attr.to_owned().execution, String::from("Something"));
   }
 


### PR DESCRIPTION
* The piping thread of writing processes' stats data into file -> then reading through a global shared variable using `Arc` (Atomically Reference Counted) and `Mutex` (Mutuals Exclusion) to synchronize the status of our machine's processes tree's snapshot has been frozen after a finite time of triggering, due to the fact that we use an infinite loop to keep tracking all of the minimum processes' revisions.
* Needs to investigate properly to find out a better solution in the future, maybe. 